### PR TITLE
Removed .php extensions

### DIFF
--- a/data/scripts/valadoc.js
+++ b/data/scripts/valadoc.js
@@ -195,7 +195,7 @@ $(document).ready(function () {
         hovered = false
       })
       self.attr('title', '') // hide browser-tooltips
-      $.get('/tooltip.php?fullname=' + encodeURIComponent(fullname), function (data) {
+      $.get('/tooltip?fullname=' + encodeURIComponent(fullname), function (data) {
         self.wTooltip({
           content: data,
           className: 'tooltip',
@@ -280,7 +280,7 @@ $(document).ready(function () {
         curpost = null
       }
       var curpkg = clean_path().split('/')[1]
-      curpost = $.post('/search.php', { query: value, curpkg: curpkg }, function (data) {
+      curpost = $.post('/search', { query: value, curpkg: curpkg }, function (data) {
         if (scrollxhr) {
           scrollxhr.abort()
           scrollxhr = null
@@ -344,7 +344,7 @@ $(document).ready(function () {
       }
       var numresults = sr.children().length
       var curpkg = clean_path().split('/')[1]
-        scrollxhr = $.post('/search.php', { query: value, curpkg: curpkg, offset: numresults }, function (data) {
+        scrollxhr = $.post('/search', { query: value, curpkg: curpkg, offset: numresults }, function (data) {
         scrollxhr = null
         $('.search-more').remove()
         sr.append(data)

--- a/src/valadoc-app.vala
+++ b/src/valadoc-app.vala
@@ -89,7 +89,7 @@ namespace Valadoc {
 			}
 		});
 
-		app.post ("/search.php", accept ("text/html", (req, res) => {
+		app.post ("/search", accept ("text/html", (req, res) => {
 			var form = Soup.Form.decode (req.flatten_utf8 ());
 			Gda.Set search_params;
 			var search_statement = db.parse_sql_string ("""
@@ -118,7 +118,7 @@ namespace Valadoc {
 			return res.end ();
 		}));
 
-		app.post ("/tooltip.php", accept ("text/html", (req, res) => {
+		app.post ("/tooltip", accept ("text/html", (req, res) => {
 			Gda.Set tooltip_params;
 			var tooltip_statement = db.parse_sql_string ("""
 			SELECT type, name, shortdesc, path, signature, namelen


### PR DESCRIPTION
`search.php` becomes `search`, and `tooltip.php` is now `tooltip`. It seems more logical like this, since we don't use PHP anymore.